### PR TITLE
fix(ci): Go merged profile is missing Function.start_line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "Merging profiles..."
           if [ -f "cpu1.pprof" ] && [ -f "cpu2.pprof" ] && [ -f "cpu3.pprof" ]; then \
-            go tool pprof -proto cpu1.pprof cpu2.pprof cpu3.pprof> default.pgo; \
+            go tool pprof -proto -output=default.pgo cpu1.pprof cpu2.pprof cpu3.pprof; \
             rm cpu1.pprof cpu2.pprof cpu3.pprof; \
             echo "Profile generated at default.pgo"; \
           else \

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ profile:
 
 	@echo "Merging profiles..."
 	@if [ -f "cpu1.pprof" ] && [ -f "cpu2.pprof" ] && [ -f "cpu3.pprof" ]; then \
-		go tool pprof -proto cpu1.pprof cpu2.pprof cpu3.pprof> default.pgo; \
+		go tool pprof -proto -output=default.pgo cpu1.pprof cpu2.pprof cpu3.pprof; \
 		rm cpu1.pprof cpu2.pprof cpu3.pprof; \
 		echo "Profile generated at default.pgo"; \
 	else \


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Passing multiple profiles to go tool pprof -proto doesn't merge them correctly. The merged profile is missing Function.start_line data required by Go 1.20+.

#### What's this PR do?

##### Add

* N/A

##### Change

* @luckylittle - fix(ci): Go merged profile is missing Function.start_line

##### Remove

* N/A

#### Where should the reviewer start?

* N/A

#### How should this be manually tested?

* `make profile`

#### Risk involved?

* N/A

#### Screenshots (if appropriate)

* N/A

#### Does the documentation or dependencies need an update?

* N/A
